### PR TITLE
ledger table Put API를 구축한다.

### DIFF
--- a/server/supabase/functions/api/index.ts
+++ b/server/supabase/functions/api/index.ts
@@ -1,4 +1,8 @@
-import { get_ledger_view, post_ledger_view } from "../view/index.ts";
+import {
+  get_ledger_view,
+  post_ledger_view,
+  put_ledger_view,
+} from "../view/index.ts";
 
 console.log("This is ledger function");
 
@@ -10,6 +14,9 @@ Deno.serve(async (req: Request) => {
   }
   if (url.pathname === "/api/ledger" && method === "POST") {
     return post_ledger_view(req);
+  }
+  if (url.pathname.startsWith("/api/ledger/") && method === "PUT") {
+    return put_ledger_view(req);
   }
 
   return new Response(JSON.stringify({ error: "Method not allowed" }), {

--- a/server/supabase/functions/controller/index.ts
+++ b/server/supabase/functions/controller/index.ts
@@ -1,2 +1,3 @@
 export { default as get_controller } from "./get.controller.ts";
 export { default as post_controller } from "./post.controller.ts";
+export { default as put_controller } from "./put.controller.ts";

--- a/server/supabase/functions/controller/put.controller.ts
+++ b/server/supabase/functions/controller/put.controller.ts
@@ -1,0 +1,27 @@
+import { post_table_model } from "../model/index.ts";
+
+class put_controller {
+  private model: post_table_model;
+  constructor() {
+    this.model = new post_table_model();
+  }
+
+  async handlePut(req: Request) {
+    try {
+      const url = new URL(req.url);
+      const id = url.pathname.split("/").pop();
+      console.log("id check in controller", id);
+
+      if (!id) {
+        return { error: "ID is Required" };
+      }
+
+      const { data, error } = await this.model.put(req, id);
+      return { data, error };
+    } catch (error) {
+      return { error: error.message };
+    }
+  }
+}
+
+export default put_controller;

--- a/server/supabase/functions/model/get_table.model.ts
+++ b/server/supabase/functions/model/get_table.model.ts
@@ -22,6 +22,10 @@ class get_table_model {
     return await supabase.from("ledger").select("*").eq("item", item);
   }
 
+  async getByCount(count: number) {
+    return await supabase.from("ledger").select("*").eq("count", count);
+  }
+
   async getByPrice(price: number) {
     return await supabase.from("ledger").select("*").eq("price", price);
   }

--- a/server/supabase/functions/model/post_table.model.ts
+++ b/server/supabase/functions/model/post_table.model.ts
@@ -8,6 +8,7 @@ const supabase = createClient(
 interface PostTableModel {
   id: string;
   item: string;
+  count: number;
   price: number;
   type: boolean;
   //   created_at: string;
@@ -16,6 +17,7 @@ interface PostTableModel {
 
 interface ValidBody {
   item: string;
+  count: number;
   price: number;
   type: boolean;
 }

--- a/server/supabase/functions/view/index.ts
+++ b/server/supabase/functions/view/index.ts
@@ -1,2 +1,3 @@
 export { default as get_ledger_view } from "./get_ledger.view.ts";
 export { default as post_ledger_view } from "./post_ledger.view.ts";
+export { default as put_ledger_view } from "./put_ledger.view.ts";

--- a/server/supabase/functions/view/put_ledger.view.ts
+++ b/server/supabase/functions/view/put_ledger.view.ts
@@ -1,0 +1,42 @@
+import { put_controller } from "../controller/index.ts";
+
+const supabase = new put_controller();
+
+const put_ledger_view = async (req: Request) => {
+  const url = new URL(req.url);
+  if (url.pathname.startsWith("/api/ledger/") && req.method === "PUT") {
+    try {
+      const { data, error } = await supabase.handlePut(req);
+      console.log("data check in view", data);
+
+      //RLS 위반 오류 처리, 단, rollback 데이터 제거,예외처리는 불가. 이를 Model에서 처리
+      if (error === "RLS_POLICY_VIOLATION" || !data || data.length === 0) {
+        return new Response(
+          JSON.stringify({
+            error: "Rollback data deleted, Access denied by RLS policy",
+          }),
+          { status: 403, headers: { "Content-Type": "application/json" } }
+        );
+      }
+
+      return new Response(JSON.stringify({ data, error }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    } catch (error) {
+      console.error("Unexpected error:", error);
+      return new Response(JSON.stringify({ error: "Internal server error" }), {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+  }
+
+  console.log("PUT 요청된 URL path:", url.pathname);
+  return new Response(JSON.stringify({ error: "Method not allowed" }), {
+    status: 405,
+    headers: { "Content-Type": "application/json" },
+  });
+};
+
+export default put_ledger_view;


### PR DESCRIPTION
- close: #6 

# Goal
- [x] ledger table Put API를 구축한다.
- [x] RLS 설정을 한다. (SELECT, UPDATE)
- [x] 포스트맨으로 테스트 한다.
- [x] fieldNeme count 추가 및 확인 필요

# PUT(UPDATE) RLS 예외처리
UPDATE 같은 경우 INSERT와 달리 RLS 권한 거부 처리를 다르게 처리 한다. INSERT 같은 경우 `RLS_POLICY_VIOLATION`와 같은 error를 반환하고 RollBack이 된다. 하지만 UPDATE 같은 경우에는 data를 `null`로 처리가 되면서 배열값이 `[]`공백으로 처리가 된다. 따라 POST와 달리 다음과 같이 예외처리를 했다.

```
  //RLS 위반 오류 처리, 단, rollback 데이터 제거,예외처리는 불가. 이를 Model에서 처리
  if (error === "RLS_POLICY_VIOLATION" || !data || data.length === 0) {
    return new Response(
      JSON.stringify({
        error: "Rollback data deleted, Access denied by RLS policy",
      }),
      { status: 403, headers: { "Content-Type": "application/json" } }
    );
  }
```

# PUT model을 POST model에서 처리
PUT과 POST는 동일한 타입, 유효성 검사를 하기 때문에 PUT model을 따로 생성하지 않고 `post_model`에서 관리하게 했다.