### PR TITLE
react-hook-form을 적용한다.

### DIFF
--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -1,10 +1,23 @@
 "use client";
 
 import { useState } from "react";
+import { useForm } from "react-hook-form";
+
+interface FormValues {
+  item: string;
+  count: number;
+  price: number;
+}
 
 const Home = () => {
   const [isHeaderActive, setHeaderActive] = useState<boolean>(false);
   const [isButtonActive, setButtonActive] = useState<boolean>(true);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormValues>();
 
   const handleActive = ({
     handle,
@@ -12,6 +25,10 @@ const Home = () => {
     handle: Dispatch<SetStateAction<boolean>>;
   }) => {
     handle((prev) => !prev);
+  };
+
+  const onSubmit = (data: FormValues) => {
+    console.log(data);
   };
 
   return (
@@ -31,33 +48,50 @@ const Home = () => {
       >
         <form
           className="flex flex-col items-center justify-center w-full"
-          action=""
+          onSubmit={handleSubmit(onSubmit)}
         >
           <div className="flex justify-center gap-1 w-11/12">
-            {/* <div> */}
-            <input
-              className="border-1 p-1 w-full"
-              type="text"
-              name="name"
-              placeholder="상품"
-            />
-            {/* </div> */}
-            {/* <div> */}
-            <input
-              className="border-1 p-1 w-full"
-              type="text"
-              name="name"
-              placeholder="수량"
-            />
-            {/* </div> */}
-            {/* <div> */}
-            <input
-              className="border-1 p-1 w-full"
-              type="text"
-              name="name"
-              placeholder="가격"
-            />
-            {/* </div> */}
+            <div className="w-full">
+              <input
+                className="w-full p-1 border-1"
+                type="text"
+                placeholder="상품"
+                {...register("item", { required: "상품을 기입해야 합니다." })}
+              />
+              {errors.item && <span>{errors.item.message}</span>}
+            </div>
+            <div className="w-full">
+              <input
+                className="w-full p-1 border-1"
+                type="number"
+                placeholder="수량"
+                {...register("count", {
+                  required: "수량을 기입해야 합니다.",
+                  valueAsNumber: true,
+                  min: {
+                    value: 1,
+                    message: "수량은 1 이상이어야 합니다.",
+                  },
+                })}
+              />
+              {errors.count && <span>{errors.count.message}</span>}
+            </div>
+            <div className="w-full">
+              <input
+                className="w-full p-1 border-1"
+                type="number"
+                placeholder="가격"
+                {...register("price", {
+                  required: "가격을 기입해야 합니다.",
+                  valueAsNumber: true,
+                  min: {
+                    value: 100,
+                    message: "가격은 100원 이상이어야 합니다.",
+                  },
+                })}
+              />
+              {errors.price && <span>{errors.price.message}</span>}
+            </div>
           </div>
           <button
             className="bg-blue-500 text-white p-2 rounded-md mt-2"


### PR DESCRIPTION
- close: #8 

# Goal
- ~[ ] 컴포넌트를 분리한다.~
- [x] react-hook-form을 적용한다.

# `valueAsNumber`를 적용한다.
HTML의 input 요소에서 type="number"로 설정하더라도, 기본적으로 입력값은 문자열(string)로 처리된다. 이전 `FormValues`의 타입을 보면 string으로 정의가 되어 있다. `valueAsNumber`는 입력값이 자동으로 문자열이 아닌 숫자로 변환이 된다. 혹시라도 string과 같은 타입으로 문자가 들어갈 수 있기 때문에 min과 같은 검징 속성이 동작하지 않을 수 있기 때문이다. 따라서 `FormValues`의 타입에 count를 number로 변경을 하고 input의 type또한 number로 맞췄다. 앞서 말했듯, 입력값이 문자열(string)으로 처리가 되기 때문에 `count` 데이터 필드와 맞지않아 타입의 안정성이 좋지 않다고 판단이 된다. 아무리 `valueAsNumber` 속성이 있다해서 입력값을 string으로 두는 것은 사용자 입장에서도 좋은 UX를 제공하지 않고, 데이터 포멧에도 맞지 않기 때문에 이를 통일 시켰다.